### PR TITLE
chore: bump aidial-sdk from 0.16.0 to 0.19.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1847,6 +1847,21 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
+name = "pytest-dotenv"
+version = "0.5.2"
+description = "A py.test plugin that parses environment files before running tests"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytest-dotenv-0.5.2.tar.gz", hash = "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732"},
+    {file = "pytest_dotenv-0.5.2-py3-none-any.whl", hash = "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f"},
+]
+
+[package.dependencies]
+pytest = ">=5.0.0"
+python-dotenv = ">=0.9.1"
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -2459,4 +2474,4 @@ examples = ["aiostream", "numpy", "pillow", "spacy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<4.0"
-content-hash = "ee91a40b8f47a79064e9506b0228ca32d752a424214742de53a8158babc8e675"
+content-hash = "5faf2d013b333d5cef2b9f355a99b1ac25a66610b0674ebb73b9c04ed45a2f98"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "aidial-sdk"
-version = "0.16.0"
+version = "0.19.0"
 description = "Framework to create applications and model adapters for AI DIAL"
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "aidial_sdk-0.16.0-py3-none-any.whl", hash = "sha256:76bfa50fd08bfabedd572f06974c68cca9dc18b5c38a8d00bf5d59e1f61cb2d9"},
-    {file = "aidial_sdk-0.16.0.tar.gz", hash = "sha256:eddb1f00949bd0e4263c18be03df7b80093ce8caf7e4ed46a550f3a790e01875"},
+    {file = "aidial_sdk-0.19.0-py3-none-any.whl", hash = "sha256:3f9e6d6d37b96aa5df22a53fefa757ac8a22a0361f6eb0b964985ab1b9b67715"},
+    {file = "aidial_sdk-0.19.0.tar.gz", hash = "sha256:7ff9d802f1af5c2fd50a9b17ccd25f5f768e75f50f140b4f69b13863b0d398b8"},
 ]
 
 [package.dependencies]
@@ -2474,4 +2474,4 @@ examples = ["aiostream", "numpy", "pillow", "spacy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<4.0"
-content-hash = "5faf2d013b333d5cef2b9f355a99b1ac25a66610b0674ebb73b9c04ed45a2f98"
+content-hash = "92d0e84bd8b2409c248770c783f38980e1cac7a0ed1bb7efa9f0bf276169d01e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,6 @@ repository = "https://github.com/epam/ai-dial-interceptors-sdk"
 clean = "scripts.clean:main"
 codegen = "scripts.codegen:main"
 
-[pytest]
-env_files = [".env"]
-
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"
 fastapi = ">=0.51,<1.0"
@@ -39,6 +36,7 @@ examples = ["aiostream", "pillow", "numpy", "spacy"]
 [tool.poetry.group.test.dependencies]
 pytest = "7.4.0"
 pytest-asyncio = "0.21.1"
+pytest-dotenv = "^0.5.2"
 python-dotenv = "1.0.0"
 
 [tool.poetry.group.lint.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ python = ">=3.11,<4.0"
 fastapi = ">=0.51,<1.0"
 httpx = ">=0.25.0,<1.0"
 openai = ">=1.32.0,<2.0"
-aidial-sdk = { version = "^0.16.0", extras = ["telemetry"] }
+aidial-sdk = { version = "^0.19.0", extras = ["telemetry"] }
 
 # Extras for examples
 aiostream = { version = "^0.6.2", optional = true }


### PR DESCRIPTION
Resolves #24 

In the long run, we should migrate to DIAL SDK with relaxed request validation to obviate fixes like this one.
