### PR TITLE
fix: avoid passing interceptor configuration to the upstream

### DIFF
--- a/aidial_interceptors_sdk/chat_completion/adapter.py
+++ b/aidial_interceptors_sdk/chat_completion/adapter.py
@@ -25,6 +25,7 @@ from aidial_interceptors_sdk.dial_client import DialClient
 from aidial_interceptors_sdk.error import EarlyStreamExit
 from aidial_interceptors_sdk.utils._debug import debug_logging
 from aidial_interceptors_sdk.utils._dial_sdk import (
+    cleanup_interceptor_configuration,
     parse_interceptor_configuration,
 )
 from aidial_interceptors_sdk.utils._exceptions import dial_exception_decorator
@@ -84,6 +85,7 @@ def interceptor_to_chat_completion(
             request_body = await debug_logging("request")(
                 interceptor.traverse_request
             )(request_body)
+            request_body = cleanup_interceptor_configuration(request_body)
 
             try:
                 await interceptor.on_stream_start()

--- a/aidial_interceptors_sdk/utils/_dial_sdk.py
+++ b/aidial_interceptors_sdk/utils/_dial_sdk.py
@@ -30,17 +30,30 @@ def send_chunk_to_response(response: Response, chunk: BaseChunk | dict):
         response._queue.put_nowait(chunk)
 
 
+_CONFIGURATION_KEY = "interceptor_configuration"
+
+
+def cleanup_interceptor_configuration(request_body: dict) -> dict:
+    """Leave no traces of the interceptor configuration in the request to the upstream."""
+
+    if (cf := request_body.get("custom_fields")) is not None:
+        cf.pop(_CONFIGURATION_KEY, None)
+        if not cf:
+            request_body.pop("custom_fields")
+
+    return request_body
+
+
 _T = TypeVar("_T", bound=BaseModel)
 
 
 def parse_interceptor_configuration(
     request: Request, cls: Type[_T] | None
 ) -> _T | None:
-    _conf_key = "interceptor_configuration"
 
     config: dict | None = None
     if cf := request.custom_fields:
-        config = cf.dict().get(_conf_key)
+        config = cf.dict().get(_CONFIGURATION_KEY)
 
     if config is not None:
         _log.debug(f"interceptor configuration: {json.dumps(config)}")
@@ -50,7 +63,7 @@ def parse_interceptor_configuration(
             return None
         case (None, _):
             raise RequestValidationError(
-                f"The interceptor doesn't have configuration, but it was provided in the chat completion request. Path: 'custom_fields.{_conf_key}'"
+                f"The interceptor doesn't have configuration, but it was provided in the chat completion request. Path: 'custom_fields.{_CONFIGURATION_KEY}'"
             )
         case (_, _):
             try:
@@ -59,6 +72,6 @@ def parse_interceptor_configuration(
             except pydantic.ValidationError as e:
                 error = e.errors()[0]
                 path = ".".join(map(str, error["loc"]))
-                msg = f"Invalid request. Path: 'custom_fields.{_conf_key}.{path}', error: {decapitalize(error['msg'])}"
+                msg = f"Invalid request. Path: 'custom_fields.{_CONFIGURATION_KEY}.{path}', error: {decapitalize(error['msg'])}"
 
                 raise RequestValidationError(msg)

--- a/tests/unit_tests/test_configuration.py
+++ b/tests/unit_tests/test_configuration.py
@@ -4,12 +4,16 @@ from typing import Type
 import httpx
 import openai
 import pytest
+from aidial_sdk.exceptions import InvalidRequestError
 from pydantic import BaseModel
 
 from aidial_interceptors_sdk.chat_completion.base import (
     ChatCompletionInterceptor,
 )
-from tests.utils.applications import EchoApplication
+from tests.utils.applications import (
+    EchoApplication,
+    RequestValidationApplication,
+)
 from tests.utils.dial_app import create_openai_client
 
 
@@ -44,6 +48,44 @@ def create_configurable_interceptor(
             raise ValueError(config)
 
     return _Impl
+
+
+def test_interceptor_configuration_cleanup(stream: bool):
+    class _NoopInterceptor(ChatCompletionInterceptor):
+        @classmethod
+        async def configuration_schema(cls):
+            return RequiredConf
+
+    def _checker(request):
+        if request.get("custom_fields") is not None:
+            raise InvalidRequestError("custom_fields should be removed")
+
+    echo = RequestValidationApplication(on_request_body=_checker)
+
+    openai_client = create_openai_client(
+        [("echo", echo), ("intr", _NoopInterceptor)],
+        ["intr", "echo"],
+    )
+
+    response = openai_client.chat.completions.create(
+        model=None,  # type: ignore
+        stream=stream,
+        messages=[{"role": "user", "content": "hello"}],
+        extra_body={
+            "custom_fields": {
+                "interceptor_configuration": {"name": "xyz", "count": 11}
+            }
+        },
+    )
+
+    if isinstance(response, openai.Stream):
+        content = "".join(
+            chunk.choices[0].delta.content or "" for chunk in response
+        )
+    else:
+        content = response.choices[0].message.content
+
+    assert content == "hello"
 
 
 def test_configuration_and_no_schema(stream: bool):


### PR DESCRIPTION
The implementation details of a configurable interceptor must not leak to the upstream. To guarantee this we need to modify the request before sending it to the upstream in the following way:
1. remove `custom_fields.interceptor_configuration`,
2. remove `custom_fields` if it's empty.

In the long run, we need to implement this request modification on the DIAL Core side. Currently, DIAL Core doesn't do (2) (see https://github.com/epam/ai-dial-core/pull/1122)